### PR TITLE
Fixing "Visualize" (in CKAN) button formatting

### DIFF
--- a/wp-open-data-toronto/page-dataset.php
+++ b/wp-open-data-toronto/page-dataset.php
@@ -176,7 +176,7 @@
                           </div>
                           <div class="col-md-3 explore-column">
 
-                              <a class="btn btn-outline-primary" type="button" id="redirect-ckan" href="#" target="_blank">
+                              <a class="btn btn-outline-primary" id="redirect-ckan" href="#" target="_blank">
                                 <span class="fa fa-area-chart"></span>&nbsp;Visualize
                                 <span class="sr-only"> Visualize data in new window</span>
                                 </a>


### PR DESCRIPTION
The "type" in the <a> was throwing off the formatting. After removing it the behaviour emulates that of the section above.