### PR TITLE
Accordion updates

### DIFF
--- a/wp-open-data-toronto/js/page-dataset.js
+++ b/wp-open-data-toronto/js/page-dataset.js
@@ -157,27 +157,23 @@ function queryViews() {
             exploreFound = false;
 
         for (var i in results) {
-            var isMapView = config['package']['dataset_category'] == 'Map' && results[i]['view_type'] == 'recline_map_view',
-                isTableView = config['package']['dataset_category'] == 'Table' && results[i]['view_type'] == 'recline_view';
-
-            if (isMapView || isTableView) {
+            if (['Map', 'Table'].indexOf(config['package']['dataset_category']) != -1) {
                 var viewURL = config['ckanURL'] + '/dataset/' + config['package']['name'] + '/resource/' + results[i]['resource_id'] + '/view/' + results[i]['id'];
 
-                if (isMapView) {
-                    var w = $('#body-dataPreview').width();
-
-                    $('#content-preview').append('<iframe width="' + w +  '" height="520" style="display: block;" src="' + viewURL + '" frameBorder="0"></iframe>');
-                } else {
+                if (config['package']['dataset_category'] == 'Map' && results[i]['view_type'] == 'recline_map_view') {
+                    if (!$('#content-preview iframe').length) {
+                        var w = $('#body-dataPreview').width();
+                        $('#content-preview').append('<iframe width="' + w +  '" height="520" style="display: block;" src="' + viewURL + '" frameBorder="0"></iframe>');
+                    }
+                } else if (results[i]['view_type'] == 'recline_view') {
                     $('#redirect-ckan').attr('href', viewURL);
                     exploreFound = true;
                 }
-
-                break;
             }
         }
 
         if (!exploreFound) {
-            $('#collapse-explore').addClass('inactive').html('<div class="not-available">Not available for this dataset</div>');
+            $('#body-Explore .card-body').html('<div class="not-available">Not available for this dataset</div>');
         }
     });
 }

--- a/wp-open-data-toronto/js/page-dataset.js
+++ b/wp-open-data-toronto/js/page-dataset.js
@@ -137,7 +137,8 @@ function buildDataset(response) {
 
     buildUI();
 
-    if (config['package']['preview_resource'] != undefined && !$.isEmptyObject(config['package']['preview_resource'])) {
+    var previewResource = config['package']['preview_resource'];
+    if (previewResource != undefined && !$.isEmptyObject(previewResource) && previewResource['datastore_active']) {
         queryContents();
         queryViews();
     } else {
@@ -213,7 +214,9 @@ function queryContents() {
             previewTable.find('tbody').append(row);
         }
 
-        if (config['package']['dataset_category'] == 'Table') { $('#content-preview').append(previewTable) };
+        if (config['package']['dataset_category'] == 'Table') {
+            $('#content-preview').append(previewTable)
+        }
         $('#content-features').append(featuresTable);
     });
 }
@@ -313,8 +316,9 @@ function generateSnippets() {
         'package <- content(response, "parsed")',
         'print(package)'
     ]
-
-    if (config['package']['preview_resource'] != undefined && !$.isEmptyObject(config['package']['preview_resource'])) {
+    
+    var previewResource = config['package']['preview_resource'];
+    if (previewResource != undefined && !$.isEmptyObject(previewResource) && previewResource['datastore_active']) {
         snippets['python'] = snippets['python'].concat([
             '',
             '# Get the data by passing the resource_id to the datastore_search endpoint',


### PR DESCRIPTION
Resolve issue related to inconsistent behaviors between CKAN data types and content shown on dataset pages:
- CKAN explore button broken for maps
- Resolve cases when preview is empty and not showing the right message in the preview accordion