### PR TITLE
Fix dataset page name

### DIFF
--- a/wp-open-data-toronto/functions.php
+++ b/wp-open-data-toronto/functions.php
@@ -9,8 +9,8 @@ register_activation_hook( __FILE__, 'custom_flush_rewrites' );
 
 function custom_url_rewrite() {
     add_rewrite_rule(
-        '^package/([^/]+)([/]?)(.*)/?$',
-        'index.php?pagename=package&package=$matches[1]',
+        '^dataset/([^/]+)([/]?)(.*)/?$',
+        'index.php?pagename=dataset&dataset=$matches[1]',
         'top'
     );
 }

--- a/wp-open-data-toronto/js/homepage.js
+++ b/wp-open-data-toronto/js/homepage.js
@@ -11,7 +11,7 @@ function init() {
             var row = data['results'][i];
 
             $('.newsfeed').append('<li>' +
-                                    '<a href="/package/' + row['name'] + '/">' +
+                                    '<a href="/dataset/' + row['name'] + '/">' +
                                       row['title'] +
                                       '<div class="float-right">' +
                                         '<span class="sr-only">Published on:</span>' + getTimeSince(row['metadata_created']) +

--- a/wp-open-data-toronto/js/page-catalogue.js
+++ b/wp-open-data-toronto/js/page-catalogue.js
@@ -55,7 +55,7 @@ function buildCatalogue(response) {
               '<div class="row">' +
                 '<div class="col-md-9">' +
                   '<div class="col-md-12">' +
-                    '<h3><a href="/package/' + row['name'] + '/">' + row['title'] + '</a></h3>' +
+                    '<h3><a href="/dataset/' + row['name'] + '/">' + row['title'] + '</a></h3>' +
                     '<p class="dataset-excerpt">' + row['excerpt'] + '</p>' +
                   '</div>' +
                 '</div>' +

--- a/wp-open-data-toronto/js/page-dataset.js
+++ b/wp-open-data-toronto/js/page-dataset.js
@@ -227,6 +227,10 @@ function queryContents() {
  */
 
 function buildUI() {
+    $('a, button').on('mouseup', function() {
+        $(this).blur();
+    });
+
     $('code').each(function(i, block) {
         hljs.highlightBlock(block);
         hljs.lineNumbersBlock(block);

--- a/wp-open-data-toronto/page-dataset.php
+++ b/wp-open-data-toronto/page-dataset.php
@@ -244,9 +244,8 @@
 
 <script type="text/javascript">
     jQuery(document).ready(function($) {
-        var package_name = '<?php echo get_query_var( 'package' ) ?>';
-        init(package_name);
-        $("a, button").on('mouseup', function(){ this.blur() });
+        var datasetName = '<?php echo get_query_var( 'dataset' ) ?>';
+        init(datasetName);
     });
 </script>
 


### PR DESCRIPTION
Update dataset URLs - to reflect change in WP we will need to update page name and then flush URL rules (by disable then re-enable this theme)